### PR TITLE
Fix #1 with a pre-release version of phantom js

### DIFF
--- a/sage.py
+++ b/sage.py
@@ -12,11 +12,16 @@ BRANDEIS_ID = os.environ['BRANDEIS_ID'] #Your Brandeis username from environment
 BRANDEIS_PASSWORD = os.environ['BRANDEIS_PASSWORD']     #Your Brandeis password from environment variable
 SEMESTER = 0                            #Semester count from the most recent (0th semester is the most recent one after registration, 1st is the one before that, etc.)
 SPEED_CONSTANT = 5                      #Number of seconds to wait for page redirection
+HEADLESS = True
 
 def get_grades():
     #Setup
 
-    browser = webdriver.Firefox()
+    if HEADLESS:
+        dirname, filename = os.path.split(os.path.abspath(__file__))
+        browser = webdriver.PhantomJS(dirname + '/phantomjs')
+    else:
+        browser = webdriver.Firefox()
 
     #Sage Login Page
 


### PR DESCRIPTION
I stumbled into this [pre-release 2.0.1 version](https://github.com/Vitallium/phantomjs/releases/tag/2.0.1) of PhantomJS and got it to work headless on the latest Mac OS. (The 2.0 version is not working on El Captain)

However, this version hasn't been approved by upstream source on Homebrew, so we can't download it with `brew install`, so I included it in the source code.

Now, there is a HEADLESS flag in the source code where you can choose to run with the window or without the window. The default is without the window.

I have tested it on Macbook Pro (El Captain) and it works great: getting result within 10 seconds.
